### PR TITLE
Fix illegal access of private field

### DIFF
--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
@@ -130,6 +130,7 @@ public class DimensionIdsFixer {
 	static {
 		try {
 			FABRIC_DIMENSION_TYPE$RAW_ID = FabricDimensionType.class.getDeclaredField("fixedRawId");
+			FABRIC_DIMENSION_TYPE$RAW_ID.setAccessible(true);
 		} catch (NoSuchFieldException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
`FabricDimensionType#fixedRawId` is private so `DimensionIdsFixer` won't be able to reflect it directly